### PR TITLE
Adding readline.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.readline?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=135&branchName=master)
+
+# readline
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,0 +1,1 @@
+plan_name : "readline"

--- a/controls/readline_test.rb
+++ b/controls/readline_test.rb
@@ -1,0 +1,51 @@
+title 'Tests to confirm readline works as expected'
+
+plan_name = input('plan_name', value: 'readline')
+plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
+hab_path = input('hab_path', value: 'hab')
+
+control 'core-plans-readline' do
+  impact 1.0
+  title 'Ensure readline works'
+  desc '
+  There are two main tests to perform for readline.  We check that the shared library exists in
+  the correct location and also that ldd works and shows ncurses is linked.
+
+    $ ls -al /hab/pkgs/core/readline/8.0/20200305232850/lib/libreadline.so
+    lrwxrwxrwx 1 root root 16 Mar  5 23:29 /hab/pkgs/core/readline/8.0/20200305232850/lib/libreadline.so -> libreadline.so.8
+
+    $ ldd libreadline.so
+    linux-vdso.so.1 (0x00007ffe4c3d0000)
+    libncursesw.so.6 => libncursesw.so.6 (0x00007f8169b56000)
+    libc.so.6 => libc.so.6 (0x00007f8169993000)
+    libtinfow.so.6 => libtinfow.so.6 (0x00007f8169953000)
+    ld-linux-x86-64.so.2 (0x00007f8169bf7000)
+  '
+  readline_pkg_ident = command("#{hab_path} pkg path #{plan_ident}")
+  describe readline_pkg_ident do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+  readline_pkg_ident = readline_pkg_ident.stdout.strip
+
+  describe command("ls -al #{readline_pkg_ident}/lib/libreadline.so") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /#{readline_pkg_ident}/ }
+    its('stderr') { should be_empty }
+  end
+
+  glibc = command("#{hab_path} pkg path core/glibc")
+  describe glibc do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+  glibc = glibc.stdout.strip
+
+  describe command("#{glibc}/bin/ldd #{readline_pkg_ident}/lib/libreadline.so") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /ncurses/ }
+    its('stderr') { should be_empty }
+  end
+end

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,7 +1,7 @@
-name: {{plan_name}}
-title: Habitat Core Plan {{plan_name}}
+name: readline
+title: Habitat Core Plan readline
 maintainer: humans@habitat.sh
-summary: InSpec controls for testing Habitat Core Plan {{plan_name}}
+summary: InSpec controls for testing Habitat Core Plan readline
 copyright: humans@habitat.sh
 copyright_email: humans@habitat.sh
 version: 0.1.0

--- a/link-against-ncurses.patch
+++ b/link-against-ncurses.patch
@@ -1,0 +1,15 @@
+Thanks to:
+https://github.com/NixOS/nixpkgs/blob/release-15.09/pkgs/development/libraries/readline/link-against-ncurses.patch
+
+diff -ur readline-6.3.orig/shlib/Makefile.in readline-6.3/shlib/Makefile.in
+--- readline-6.3.orig/shlib/Makefile.in 2012-01-12 21:54:33.000000000 +0000
++++ readline-6.3/shlib/Makefile.in      2016-01-11 22:15:29.151616957 +0000
+@@ -85,7 +85,7 @@
+ SHOBJ_XLDFLAGS = @SHOBJ_XLDFLAGS@
+ SHOBJ_LIBS = @SHOBJ_LIBS@
+
+-SHLIB_XLDFLAGS = @LDFLAGS@ @SHLIB_XLDFLAGS@
++SHLIB_XLDFLAGS = @LDFLAGS@ @SHLIB_XLDFLAGS@ -lncurses
+ SHLIB_LIBS = @SHLIB_LIBS@
+
+ SHLIB_DOT = @SHLIB_DOT@

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,107 @@
+pkg_name=readline
+_distname="$pkg_name"
+pkg_origin=core
+_base_version=8.0
+pkg_version=${_base_version}
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="\
+The GNU Readline library provides a set of functions for use by applications \
+that allow users to edit command lines as they are typed in.\
+"
+pkg_upstream_url="http://tiswww.case.edu/php/chet/readline/rltop.html"
+pkg_license=('GPL-3.0')
+_url_base="http://ftp.gnu.org/gnu/${_distname}"
+pkg_source="${_url_base}/${_distname}-${_base_version}.tar.gz"
+pkg_shasum="e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461"
+pkg_dirname="${_distname}-${_base_version}"
+pkg_deps=(
+  core/glibc
+  core/ncurses
+)
+pkg_build_deps=(
+  core/coreutils
+  core/diffutils
+  core/patch
+  core/make
+  core/gcc
+  core/bison
+  core/grep
+)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)
+
+do_begin() {
+  # The maintainer of Readline only releases these patches to fix serious
+  # issues, so any new official patches will be part of this build, which will
+  # be reflected in the "tiny" or "patch" number of the version coordinate. In
+  # other words, given 6 patches, the version of this Readline package would be
+  # `MAJOR.MINOR.6`.
+
+  # Source a file containing an array of patch URLs and an array of patch file
+  # shasums
+  source "${PLAN_CONTEXT}/readline-patches.sh"
+}
+
+do_download() {
+  do_default_download
+
+  # Download all patch files, providing the corresponding shasums so we can
+  # skip re-downloading if already present and verified
+  for i in $(seq 0 $((${#_patch_files[@]} - 1))); do
+    p="${_patch_files[$i]}"
+    download_file "$p" "$(basename "$p")" "${_patch_shasums[$i]}"
+  done; unset i p
+}
+
+do_verify() {
+  do_default_verify
+
+  # Verify all patch files against their shasums
+  for i in $(seq 0 $((${#_patch_files[@]} - 1))); do
+    verify_file "$(basename "${_patch_files[$i]}")" "${_patch_shasums[$i]}"
+  done; unset i
+}
+
+do_prepare() {
+  do_default_prepare
+
+  # Apply all patch files to the extracted source
+  for p in "${_patch_files[@]}"; do
+    build_line "Applying patch $(basename "$p")"
+    patch -p0 -i "${HAB_CACHE_SRC_PATH}/$(basename "$p")"
+  done
+
+  # This patch is to make sure that `libncurses' is among the `NEEDED'
+  # dependencies of `libreadline.so' and `libhistory.so'. Failing to do that,
+  # applications linking against Readline are forced to explicitly link against
+  # libncurses as well; in addition, this trick doesn't work when using GNU
+  # ld's `--as-needed'.
+  #
+  # Thanks to:
+  # https://github.com/NixOS/nixpkgs/blob/release-15.09/pkgs/development/libraries/readline/link-against-ncurses.patch
+  build_line "Applying patch link-against-ncurses.patch"
+  patch -p1 -i "${PLAN_CONTEXT}/../readline/link-against-ncurses.patch"
+}
+
+do_install() {
+  do_default_install
+
+  # An empty `bin/` directory gets made, which we don't need and is confusing
+  rm -rf "${pkg_prefix:?}/bin"
+}
+
+
+# ----------------------------------------------------------------------------
+# **NOTICE:** What follows are implementation details required for building a
+# first-pass, "stage1" toolchain and environment. It is only used when running
+# in a "stage1" Studio and can be safely ignored by almost everyone. Having
+# said that, it performs a vital bootstrapping process and cannot be removed or
+# significantly altered. Thank you!
+# ----------------------------------------------------------------------------
+if [[ "$STUDIO_TYPE" = "stage1" ]]; then
+  pkg_build_deps=(
+    core/gcc
+    core/bison
+    core/grep
+  )
+fi

--- a/plan.sh
+++ b/plan.sh
@@ -80,7 +80,7 @@ do_prepare() {
   # Thanks to:
   # https://github.com/NixOS/nixpkgs/blob/release-15.09/pkgs/development/libraries/readline/link-against-ncurses.patch
   build_line "Applying patch link-against-ncurses.patch"
-  patch -p1 -i "${PLAN_CONTEXT}/../readline/link-against-ncurses.patch"
+  patch -p1 -i "$PLAN_CONTEXT/link-against-ncurses.patch"
 }
 
 do_install() {

--- a/readline-patches.sh
+++ b/readline-patches.sh
@@ -1,0 +1,7 @@
+_patch_url_base="${_url_base}/${_distname}-${_base_version}-patches/${_distname}${_base_version//.}"
+
+# All official patch file URLs
+_patch_files=()
+
+# All official patch file shasums
+_patch_shasums=()

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,0 +1,12 @@
+@test "libreadline.so exists" {
+  [ -f "/hab/pkgs/$TEST_PKG_IDENT/lib/libreadline.so" ]
+}
+
+# Check that the patch to link to ncurses works
+@test "libreadline.so is linked to ncurses" {
+  ldd /hab/pkgs/$TEST_PKG_IDENT/lib/libreadline.so | grep ncurses
+}
+
+@test "libhistory.so is linked to ncurses" {
+  ldd /hab/pkgs/$TEST_PKG_IDENT/lib/libhistory.so | grep ncurses
+}

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -euo pipefail
+
+TESTDIR="$(dirname "${0}")"
+
+if [ -z "${1:-}" ]; then
+  echo "Usage: $0 FULLY_QUALIFIED_PACKAGE_IDENT"
+  exit 1
+fi
+
+TEST_PKG_IDENT="$1"
+
+hab pkg install core/bats --binlink
+hab pkg install "$TEST_PKG_IDENT"
+
+export TEST_PKG_IDENT
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
Migration from core plans adding inspec tests.

```
Profile: Habitat Core Plan readline (readline)
Version: 0.1.0
Target:  docker://b0ea02b8efa3ed751609d90b657a8bcd4e23378dcdb75e3abbc832612819f493

  ✔  core-plans-readline: Ensure readline works
     ✔  Command: `hab pkg path habskp/readline` exit_status is expected to eq 0
     ✔  Command: `hab pkg path habskp/readline` stdout is expected not to be empty
     ✔  Command: `ls -al /hab/pkgs/habskp/readline/8.0/20200611144227/lib/libreadline.so` exit_status is expected to eq 0
     ✔  Command: `ls -al /hab/pkgs/habskp/readline/8.0/20200611144227/lib/libreadline.so` stdout is expected not to be empty
     ✔  Command: `ls -al /hab/pkgs/habskp/readline/8.0/20200611144227/lib/libreadline.so` stdout is expected to match /\/hab\/pkgs\/habskp\/readline\/8.0\/20200611144227/
     ✔  Command: `ls -al /hab/pkgs/habskp/readline/8.0/20200611144227/lib/libreadline.so` stderr is expected to be empty
     ✔  Command: `hab pkg path core/glibc` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/glibc` stdout is expected not to be empty
     ✔  Command: `/hab/pkgs/core/glibc/2.29/20200305172459/bin/ldd /hab/pkgs/habskp/readline/8.0/20200611144227/lib/libreadline.so` exit_status is expected to eq 0
     ✔  Command: `/hab/pkgs/core/glibc/2.29/20200305172459/bin/ldd /hab/pkgs/habskp/readline/8.0/20200611144227/lib/libreadline.so` stdout is expected not to be empty
     ✔  Command: `/hab/pkgs/core/glibc/2.29/20200305172459/bin/ldd /hab/pkgs/habskp/readline/8.0/20200611144227/lib/libreadline.so` stdout is expected to match /ncurses/
     ✔  Command: `/hab/pkgs/core/glibc/2.29/20200305172459/bin/ldd /hab/pkgs/habskp/readline/8.0/20200611144227/lib/libreadline.so` stderr is expected to be empty
```

﻿Signed-off-by: Stuart Paterson <spaterson@chef.io>
